### PR TITLE
Honor properties sortOrder in the edit dialog

### DIFF
--- a/src/Our.Umbraco.DocTypeGridEditor/Web/Controllers/DocTypeGridEditorApiController.cs
+++ b/src/Our.Umbraco.DocTypeGridEditor/Web/Controllers/DocTypeGridEditorApiController.cs
@@ -7,6 +7,7 @@ using Umbraco.Core.Models;
 using Umbraco.Core.PropertyEditors;
 using Umbraco.Web.Editors;
 using Umbraco.Web.Mvc;
+using Umbraco.Web;
 
 namespace Our.Umbraco.DocTypeGridEditor.Web.Controllers
 {
@@ -82,6 +83,36 @@ namespace Our.Umbraco.DocTypeGridEditor.Web.Controllers
             var preValue = Services.DataTypeService.GetPreValuesCollectionByDataTypeId(dtd.Id);
             var propEditor = PropertyEditorResolver.Current.GetByAlias(dtd.PropertyEditorAlias);
             return propEditor.PreValueEditor.ConvertDbToEditor(propEditor.DefaultPreValues, preValue);
+        }
+
+        [System.Web.Http.HttpGet]
+        public List<PropertyType> GetContentTypePropertyTypes(String alias)
+        {
+            var list = new List<PropertyType>();
+            var doctype = UmbracoContext.Application.Services.ContentTypeService.GetContentType(alias);
+            if (doctype != null)
+            {
+                list = doctype.PropertyTypes.ToList();
+                if (doctype.ParentId != 0)
+                {
+                    list.AddRange(GetContentTypePropertyTypes(doctype.ParentId));
+                }
+            }
+            return list;
+        }
+        private List<PropertyType> GetContentTypePropertyTypes(int id)
+        {
+            var list = new List<PropertyType>();
+            var doctype = UmbracoContext.Application.Services.ContentTypeService.GetContentType(id);
+            if (doctype != null)
+            {
+                list = doctype.PropertyTypes.ToList();
+                if (doctype.ParentId != 0)
+                {
+                    list.AddRange(GetContentTypePropertyTypes(doctype.ParentId));
+                }
+            }
+            return list;
         }
     }
 }

--- a/src/Our.Umbraco.DocTypeGridEditor/Web/UI/App_Plugins/DocTypeGridEditor/Js/doctypegrideditor.controllers.js
+++ b/src/Our.Umbraco.DocTypeGridEditor/Web/UI/App_Plugins/DocTypeGridEditor/Js/doctypegrideditor.controllers.js
@@ -212,8 +212,8 @@ angular.module("umbraco").controller("Our.Umbraco.DocTypeGridEditor.Dialogs.DocT
                     };
 
                     // Fetch and assign sortOrder to each prop
-                    dtgeResources.getContentTypePropertyTypes(data.contentTypeAlias).then(function (response) {
-                        _.each(response.data, function (e, i) {
+                    dtgeResources.getContentTypePropertyTypes(data.contentTypeAlias).then(function (data1) {
+                        _.each(data1, function (e, i) {
                             _.each(data.tabs, function (tab, j) {
                                 _.each(tab.properties, function (prop, k) {
                                     if (prop != undefined && prop.alias != undefined && e != undefined && e.Alias != undefined && prop.alias == e.Alias) {
@@ -222,7 +222,7 @@ angular.module("umbraco").controller("Our.Umbraco.DocTypeGridEditor.Dialogs.DocT
                                 });
                             });
                         });
-                    }, function (error) { });
+                    });
 
                     // Assign the model to scope
                     $scope.nodeContext = $scope.node = data;

--- a/src/Our.Umbraco.DocTypeGridEditor/Web/UI/App_Plugins/DocTypeGridEditor/Js/doctypegrideditor.controllers.js
+++ b/src/Our.Umbraco.DocTypeGridEditor/Web/UI/App_Plugins/DocTypeGridEditor/Js/doctypegrideditor.controllers.js
@@ -211,6 +211,19 @@ angular.module("umbraco").controller("Our.Umbraco.DocTypeGridEditor.Dialogs.DocT
                         }
                     };
 
+                    // Fetch and assign sortOrder to each prop
+                    dtgeResources.getContentTypePropertyTypes(data.contentTypeAlias).then(function (response) {
+                        _.each(response.data, function (e, i) {
+                            _.each(data.tabs, function (tab, j) {
+                                _.each(tab.properties, function (prop, k) {
+                                    if (prop != undefined && prop.alias != undefined && e != undefined && e.Alias != undefined && prop.alias == e.Alias) {
+                                        prop.sortOrder = e.SortOrder;
+                                    }
+                                });
+                            });
+                        });
+                    }, function (error) { });
+
                     // Assign the model to scope
                     $scope.nodeContext = $scope.node = data;
                 });

--- a/src/Our.Umbraco.DocTypeGridEditor/Web/UI/App_Plugins/DocTypeGridEditor/Js/doctypegrideditor.resources.js
+++ b/src/Our.Umbraco.DocTypeGridEditor/Web/UI/App_Plugins/DocTypeGridEditor/Js/doctypegrideditor.resources.js
@@ -51,6 +51,9 @@
                         'Content-Type': 'application/x-www-form-urlencoded'
                     }
                 });
+            },
+            getContentTypePropertyTypes: function (alias) {
+                return $http.get("Backoffice/DocTypeGridEditorApi/DocTypeGridEditorApi/GetContentTypePropertyTypes?alias=" + alias);
             }
         };
     });

--- a/src/Our.Umbraco.DocTypeGridEditor/Web/UI/App_Plugins/DocTypeGridEditor/Js/doctypegrideditor.resources.js
+++ b/src/Our.Umbraco.DocTypeGridEditor/Web/UI/App_Plugins/DocTypeGridEditor/Js/doctypegrideditor.resources.js
@@ -53,7 +53,11 @@
                 });
             },
             getContentTypePropertyTypes: function (alias) {
-                return $http.get("Backoffice/DocTypeGridEditorApi/DocTypeGridEditorApi/GetContentTypePropertyTypes?alias=" + alias);
+                var url = "/umbraco/backoffice/DocTypeGridEditorApi/DocTypeGridEditorApi/GetContentTypePropertyTypes?alias=" + alias;
+                return umbRequestHelper.resourcePromise(
+                    $http.get(url),
+                    'Failed to retrieve property types'
+                );
             }
         };
     });

--- a/src/Our.Umbraco.DocTypeGridEditor/Web/UI/App_Plugins/DocTypeGridEditor/Views/doctypegrideditor.dialog.html
+++ b/src/Our.Umbraco.DocTypeGridEditor/Web/UI/App_Plugins/DocTypeGridEditor/Views/doctypegrideditor.dialog.html
@@ -15,7 +15,7 @@
                     <legend style="font-size: 18px;">{{tab.alias}}</legend>
 
                     <umb-property property="property"
-                                  ng-repeat="property in tab.properties">
+                                  ng-repeat="property in tab.properties | orderBy:'+sortOrder'">
                         <umb-editor model="property"></umb-editor>
                     </umb-property>
 


### PR DESCRIPTION
The reason for this addition is that when a document type has inherited properties, the sort order in the form ... is a mess.

A method is added to the controller and resource to fetch the sortOrder
from the Content Type and assign it to each scaffolded property.

Then the sortOrder is used for sorting the form fields:
 ng-repeat="property in tab.properties | orderBy:'+sortOrder'"

Credit to Sentient for the idea of pulling this trick, in a slightly different context:
https://our.umbraco.org/forum/umbraco-7/using-umbraco-7/70292-sort-order-problems-with-inherited-document-type-properties