### PR TITLE
Preview fixes

### DIFF
--- a/src/Our.Umbraco.DocTypeGridEditor/Web/UI/App_Plugins/DocTypeGridEditor/Js/doctypegrideditor.controllers.js
+++ b/src/Our.Umbraco.DocTypeGridEditor/Web/UI/App_Plugins/DocTypeGridEditor/Js/doctypegrideditor.controllers.js
@@ -58,7 +58,8 @@
                     $scope.control.editor.alias, model.dtgeContentTypeAlias, model.value,
                     $scope.control.editor.config.viewPath,
                     $scope.control.editor.config.previewViewPath,
-                    !!editorState.current.publishDate)
+                    !!editorState.current.publishDate,
+                    $routeParams.section)
                     .success(function (htmlResult) {
                         if (htmlResult.trim().length > 0) {
                             $scope.preview = htmlResult;

--- a/src/Our.Umbraco.DocTypeGridEditor/Web/UI/App_Plugins/DocTypeGridEditor/Js/doctypegrideditor.resources.js
+++ b/src/Our.Umbraco.DocTypeGridEditor/Web/UI/App_Plugins/DocTypeGridEditor/Js/doctypegrideditor.resources.js
@@ -34,7 +34,7 @@
                     'Failed to retrieve datatypes'
                 );
             },
-            getEditorMarkupForDocTypePartial: function (nodeId, id, editorAlias, contentTypeAlias, value, viewPath, previewViewPath, published) {
+            getEditorMarkupForDocTypePartial: function (nodeId, id, editorAlias, contentTypeAlias, value, viewPath, previewViewPath, published, section) {
                 var url = "/" + (published ? nodeId : "") + "?dtgePreview=1" + (published ? "" : "&nodeId=" + nodeId);
                 return $http({
                     method: 'POST',

--- a/src/Our.Umbraco.DocTypeGridEditor/Web/UI/App_Plugins/DocTypeGridEditor/Js/doctypegrideditor.resources.js
+++ b/src/Our.Umbraco.DocTypeGridEditor/Web/UI/App_Plugins/DocTypeGridEditor/Js/doctypegrideditor.resources.js
@@ -45,7 +45,8 @@
                         contentTypeAlias: contentTypeAlias,
                         value: JSON.stringify(value),
                         viewPath: viewPath,
-                        previewViewPath: previewViewPath
+                        previewViewPath: previewViewPath,
+                        section: section
                     }),
                     headers: {
                         'Content-Type': 'application/x-www-form-urlencoded'

--- a/src/Our.Umbraco.DocTypeGridEditor/Web/UI/App_Plugins/DocTypeGridEditor/Render/DocTypeGridEditorPreviewer.cshtml
+++ b/src/Our.Umbraco.DocTypeGridEditor/Web/UI/App_Plugins/DocTypeGridEditor/Render/DocTypeGridEditorPreviewer.cshtml
@@ -10,8 +10,15 @@
     var value = Request.Unvalidated.Form["value"];
     var viewPath = Request.Form["viewPath"];
     var previewViewPath = Request.Form["previewViewPath"];
+    var section = Request.Form["section"];
 
-    var content = DocTypeGridEditorHelper.ConvertValueToContent(id, contentTypeAlias, value);
+    if (section == "content")
+    {
+        if (!UmbracoContext.ContentCache.HasContent(true))
+        {
+            var content = DocTypeGridEditorHelper.ConvertValueToContent(id, contentTypeAlias, value);
 
-    @Html.RenderDocTypeGridEditorItem(content, editorAlias, viewPath, previewViewPath)
+            @Html.RenderDocTypeGridEditorItem(content, editorAlias, viewPath, previewViewPath)
+        }
+    }
 }


### PR DESCRIPTION
added a condition to only render a preview if the request came from the content section, and there is content in the cache.

Partially addresses https://github.com/umco/umbraco-doc-type-grid-editor/issues/53