### PR TITLE
Issue when using multiple ApplicationEventHandler

### DIFF
--- a/src/Our.Umbraco.DocTypeGridEditor/Bootstrap.cs
+++ b/src/Our.Umbraco.DocTypeGridEditor/Bootstrap.cs
@@ -14,7 +14,10 @@ namespace Our.Umbraco.DocTypeGridEditor
         {
             GlobalFilters.Filters.Add(new DocTypeGridEditorPreviewAttribute());
 
-            DefaultDocTypeGridEditorSurfaceControllerResolver.Current = new DefaultDocTypeGridEditorSurfaceControllerResolver();
+            if (!DefaultDocTypeGridEditorSurfaceControllerResolver.HasCurrent)
+            {
+                DefaultDocTypeGridEditorSurfaceControllerResolver.Current = new DefaultDocTypeGridEditorSurfaceControllerResolver();
+            }
         }
 
         protected override void ApplicationStarted(UmbracoApplicationBase umbracoApplication, ApplicationContext applicationContext)


### PR DESCRIPTION
When using multiple ApplicationEventHandler the order can not always be specified. This allows the the default controller to be specified in another startup function.