### PR TITLE
Fix urls by converting virtual paths to absolute

### DIFF
--- a/src/Our.Umbraco.DocTypeGridEditor/Web/UI/App_Plugins/DocTypeGridEditor/Js/doctypegrideditor.resources.js
+++ b/src/Our.Umbraco.DocTypeGridEditor/Web/UI/App_Plugins/DocTypeGridEditor/Js/doctypegrideditor.resources.js
@@ -2,14 +2,14 @@
     function ($q, $http, umbRequestHelper) {
         return {
             getContentTypeAliasByGuid: function (guid) {
-                var url = "/umbraco/backoffice/DocTypeGridEditorApi/DocTypeGridEditorApi/GetContentTypeAliasByGuid?guid=" + guid;
+            	var url = umbRequestHelper.convertVirtualToAbsolutePath("~/umbraco/backoffice/DocTypeGridEditorApi/DocTypeGridEditorApi/GetContentTypeAliasByGuid?guid=" + guid);
                 return umbRequestHelper.resourcePromise(
                     $http.get(url),
                     'Failed to retrieve content type alias by guid'
                 );
             },
             getContentTypes: function (allowedContentTypes) {
-                var url = "/umbraco/backoffice/DocTypeGridEditorApi/DocTypeGridEditorApi/GetContentTypes";
+            	var url = umbRequestHelper.convertVirtualToAbsolutePath("~/umbraco/backoffice/DocTypeGridEditorApi/DocTypeGridEditorApi/GetContentTypes");
                 if (allowedContentTypes) {
                     for (var i = 0; i < allowedContentTypes.length; i++) {
                         url += (i == 0 ? "?" : "&") + "allowedContentTypes=" + allowedContentTypes[i];
@@ -21,21 +21,21 @@
                 );
             },
             getContentTypeIcon: function (contentTypeAlias) {
-                var url = "/umbraco/backoffice/DocTypeGridEditorApi/DocTypeGridEditorApi/GetContentTypeIcon?contentTypeAlias=" + contentTypeAlias;
+            	var url = umbRequestHelper.convertVirtualToAbsolutePath("~/umbraco/backoffice/DocTypeGridEditorApi/DocTypeGridEditorApi/GetContentTypeIcon?contentTypeAlias=" + contentTypeAlias);
                 return umbRequestHelper.resourcePromise(
                     $http.get(url),
                     'Failed to retrieve content type icon'
                 );
             },
             getDataTypePreValues: function (dtdId) {
-                var url = "/umbraco/backoffice/DocTypeGridEditorApi/DocTypeGridEditorApi/GetDataTypePreValues?dtdid=" + dtdId;
+            	var url = umbRequestHelper.convertVirtualToAbsolutePath("~/umbraco/backoffice/DocTypeGridEditorApi/DocTypeGridEditorApi/GetDataTypePreValues?dtdid=" + dtdId);
                 return umbRequestHelper.resourcePromise(
                     $http.get(url),
                     'Failed to retrieve datatypes'
                 );
             },
             getEditorMarkupForDocTypePartial: function (nodeId, id, editorAlias, contentTypeAlias, value, viewPath, previewViewPath, published) {
-                var url = "/" + (published ? nodeId : "") + "?dtgePreview=1" + (published ? "" : "&nodeId=" + nodeId);
+            	var url = umbRequestHelper.convertVirtualToAbsolutePath("~/" + (published ? nodeId : "") + "?dtgePreview=1" + (published ? "" : "&nodeId=" + nodeId));
                 return $http({
                     method: 'POST',
                     url: url,

--- a/src/Our.Umbraco.DocTypeGridEditor/Web/UI/App_Plugins/DocTypeGridEditor/Js/doctypegrideditor.services.js
+++ b/src/Our.Umbraco.DocTypeGridEditor/Web/UI/App_Plugins/DocTypeGridEditor/Js/doctypegrideditor.services.js
@@ -1,10 +1,10 @@
 ﻿angular.module('umbraco.services').factory('Our.Umbraco.DocTypeGridEditor.Services.DocTypeDialogService',
-    function (dialogService, editorState) {
+    function (dialogService, editorState, umbRequestHelper) {
         return {
             open: function (options) {
 
                 var o = $.extend({}, {
-                    template: "/App_Plugins/DocTypeGridEditor/Views/doctypegrideditor.dialog.html",
+                	template: umbRequestHelper.convertVirtualToAbsolutePath("~/App_Plugins/DocTypeGridEditor/Views/doctypegrideditor.dialog.html"),
                     show: true,
                     requireName: true,
                 }, options);


### PR DESCRIPTION
I ran into a problem using Doc Type Grid Editor in a child application - currently the paths simply point to the root of the site/application. This should fix that by using `umbRequestHelper.convertVirtualToAbsolutePath` to specify a virtual path and have it converted to the correct absolute path that umbraco is actually using.