### PR TITLE
Stopped rendered contents from having click events

### DIFF
--- a/src/Our.Umbraco.DocTypeGridEditor/Web/UI/App_Plugins/DocTypeGridEditor/Views/doctypegrideditor.html
+++ b/src/Our.Umbraco.DocTypeGridEditor/Web/UI/App_Plugins/DocTypeGridEditor/Views/doctypegrideditor.html
@@ -10,7 +10,8 @@
     <div ng-if="preview">
       <div
         ng-if="preview" style="text-align: left"
-        ng-bind-html-unsafe="preview">
+        ng-bind-html-unsafe="preview"
+        prevent-default>
       </div>
     </div>
   </div>


### PR DESCRIPTION
The only way to edit the doc type is by clicking on the rendered output. If the render has a link in it, then clicking on it will open the link instead of allowing you to edit the doc type. Adding "prevent-default" prevents the default for when a link is clicked on.