### PR TITLE
Helper methods for renaming aliases

### DIFF
--- a/src/Our.Umbraco.DocTypeGridEditor/Extensions/JsonExtensions.cs
+++ b/src/Our.Umbraco.DocTypeGridEditor/Extensions/JsonExtensions.cs
@@ -1,0 +1,19 @@
+﻿using System;
+using Newtonsoft.Json.Linq;
+
+namespace Our.Umbraco.DocTypeGridEditor.Extensions
+{
+    internal static class JsonExtensions
+    {
+        public static void Rename(this JToken token, string newName)
+        {
+            var parent = token.Parent;
+
+            if (parent == null)
+                throw new InvalidOperationException("The parent is missing.");
+
+            var newToken = new JProperty(newName, token);
+            parent.Replace(newToken);
+        }
+    }
+}

--- a/src/Our.Umbraco.DocTypeGridEditor/Helpers/DocTypeGridEditorHelper.cs
+++ b/src/Our.Umbraco.DocTypeGridEditor/Helpers/DocTypeGridEditorHelper.cs
@@ -10,6 +10,7 @@ using Umbraco.Core.Logging;
 using Umbraco.Core.Models;
 using Umbraco.Core.Models.Editors;
 using Umbraco.Core.Models.PublishedContent;
+using Umbraco.Core.Persistence;
 using Umbraco.Core.PropertyEditors;
 using Umbraco.Core.Services;
 using Umbraco.Web;
@@ -148,6 +149,77 @@ namespace Our.Umbraco.DocTypeGridEditor.Helpers
             return (string)ApplicationContext.Current.ApplicationCache.RuntimeCache.GetCacheItem(
                 string.Concat("Our.Umbraco.DocTypeGridEditor.Helpers.DocTypeGridEditorHelper.GetContentTypeAliasByGuid_", contentTypeGuid),
                 () => Services.ContentTypeService.GetAliasByGuid(contentTypeGuid));
+        }
+
+        public static void RemapDocTypeAlias(string oldAlias, string newAlias, Transaction transaction = null)
+        {
+            var db = ApplicationContext.Current.DatabaseContext.Database;
+
+            // Update references in property data
+            // We do 2 very similar replace statements, but one is without spaces in the JSON, the other is with spaces 
+            // as we can't guarantee what format it will actually get saved in
+            var sql1 = string.Format(@"UPDATE cmsPropertyData
+SET dataNtext = CAST(REPLACE(REPLACE(CAST(dataNtext AS nvarchar(max)), '""dtgeContentTypeAlias"":""{0}""', '""dtgeContentTypeAlias"":""{1}""'), '""dtgeContentTypeAlias"": ""{0}""', '""dtgeContentTypeAlias"": ""{1}""') AS ntext)
+WHERE dataNtext LIKE '%""dtgeContentTypeAlias"":""{0}""%' OR dataNtext LIKE '%""dtgeContentTypeAlias"": ""{0}""%'", oldAlias, newAlias);
+
+            if (transaction == null)
+            {
+                using (var tr = db.GetTransaction())
+                {
+                    db.Execute(sql1);
+                    tr.Complete();
+                }
+            }
+            else
+            {
+                db.Execute(sql1);
+            }
+        }
+
+        public static void RemapPropertyAlias(string docTypeAlias, string oldAlias, string newAlias, Transaction transaction = null)
+        {
+            var db = ApplicationContext.Current.DatabaseContext.Database;
+
+            // Update references in property data
+            // We have to do it in code because there could be nested JSON so 
+            // we need to make sure it only replaces at the specific level only
+            Action doQuery = () =>
+            {
+                var rows = GetPropertyDataRows(docTypeAlias);
+                foreach (var row in rows)
+                {
+                    var tokens = row.Data.SelectTokens(string.Format("$..controls[?(@.value.dtgeContentTypeAlias == '{0}' && @.value.value.{1})].value", docTypeAlias, oldAlias)).ToList();
+                    if (tokens.Any())
+                    {
+                        foreach (var token in tokens)
+                        {
+                            token["value"][oldAlias].Rename(newAlias);
+                        }
+                        db.Execute("UPDATE [cmsPropertyData] SET [dataNtext] = @0 WHERE [id] = @1", row.RawData, row.Id);
+                    }
+                }
+            };
+
+            if (transaction == null)
+            {
+                using (var tr = db.GetTransaction())
+                {
+                    doQuery();
+                    tr.Complete();
+                }
+            }
+            else
+            {
+                doQuery();
+            }
+        }
+
+        private static IEnumerable<JsonDbRow> GetPropertyDataRows(string docTypeAlias)
+        {
+            var db = ApplicationContext.Current.DatabaseContext.Database;
+            return db.Query<JsonDbRow>(string.Format(
+                @"SELECT [id], [dataNtext] as [rawdata] FROM cmsPropertyData WHERE dataNtext LIKE '%""dtgeContentTypeAlias"":""{0}""%' OR dataNtext LIKE '%""dtgeContentTypeAlias"": ""{0}""%'",
+                docTypeAlias)).ToList();
         }
     }
 

--- a/src/Our.Umbraco.DocTypeGridEditor/Models/JsonDbRow.cs
+++ b/src/Our.Umbraco.DocTypeGridEditor/Models/JsonDbRow.cs
@@ -1,0 +1,27 @@
+﻿using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+
+namespace Our.Umbraco.DocTypeGridEditor.Models
+{
+    /// <summary>
+    /// A utility class used to help modify JSON data from the Umbraco property data table
+    /// </summary>
+    internal class JsonDbRow
+    {
+        public int Id { get; set; }
+
+        public string RawData { get; set; }
+
+        public JToken Data
+        {
+            get
+            {
+                return (JToken)JsonConvert.DeserializeObject(RawData);
+            }
+            set
+            {
+                RawData = JsonConvert.SerializeObject(value);
+            }
+        }
+    }
+}

--- a/src/Our.Umbraco.DocTypeGridEditor/Our.Umbraco.DocTypeGridEditor.csproj
+++ b/src/Our.Umbraco.DocTypeGridEditor/Our.Umbraco.DocTypeGridEditor.csproj
@@ -275,11 +275,13 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Bootstrap.cs" />
+    <Compile Include="Extensions\JsonExtensions.cs" />
     <Compile Include="Extensions\ViewEnginesCollectionExtensions.cs" />
     <Compile Include="Helpers\DocTypeGridEditorHelper.cs" />
     <Compile Include="Helpers\XmlHelper.cs" />
     <Compile Include="Models\DetachedPublishedContent.cs" />
     <Compile Include="Models\DetachedPublishedProperty.cs" />
+    <Compile Include="Models\JsonDbRow.cs" />
     <Compile Include="PackageActions\AddObjectToJsonArray.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Properties\VersionInfo.cs" />


### PR DESCRIPTION
Adds helper methods to programmatically aid with renaming a doctype/property alias or tab name.

> Explanation on NC: https://github.com/umco/umbraco-nested-content/pull/122