### PR TITLE
Call the model factory to support typed models when used.

### DIFF
--- a/src/Our.Umbraco.DocTypeGridEditor/Helpers/DocTypeGridEditorHelper.cs
+++ b/src/Our.Umbraco.DocTypeGridEditor/Helpers/DocTypeGridEditorHelper.cs
@@ -113,10 +113,20 @@ namespace Our.Umbraco.DocTypeGridEditor.Helpers
                 var pcr = UmbracoContext.Current != null ? UmbracoContext.Current.PublishedContentRequest : null;
                 var containerNode = pcr != null && pcr.HasPublishedContent ? pcr.PublishedContent : null;
 
-                return new DetachedPublishedContent(nameObj != null ? nameObj.ToString() : null,
+                // Create the model based on our implementation of IPublishedContent
+                IPublishedContent content = new DetachedPublishedContent(
+                    nameObj != null ? nameObj.ToString() : null,
                     contentTypes.PublishedContentType,
                     properties.ToArray(),
                     containerNode);
+
+                if (PublishedContentModelFactoryResolver.HasCurrent)
+                {
+                    // Let the current model factory create a typed model to wrap our model
+                    content = PublishedContentModelFactoryResolver.Current.Factory.CreateModel(content);
+                }
+
+                return content;
             }
 
         }


### PR DESCRIPTION
The latest release of Nested Content (v0.5.0) now includes code that will try and convert the `DetachedPublishedContent` object to its relevant ModelsBuilder class (when used). 
I thought it would be useful to port that same fix to DTGE as well. This then allows the grid partial views to work directly with the generated ModelsBuilder classes and therefore should fix the issue raised in #44.

I've tried this fix locally with a few sites using DTGE and it works very well.

Full credits for this should be for @Ron-Brouwer who did the original PR for Nested Content. 👍 
I just ported his code over to DTGE.