### PR TITLE
Don't remove the last tab in version v7.8

### DIFF
--- a/src/Our.Umbraco.DocTypeGridEditor/Web/UI/App_Plugins/DocTypeGridEditor/Js/doctypegrideditor.controllers.js
+++ b/src/Our.Umbraco.DocTypeGridEditor/Web/UI/App_Plugins/DocTypeGridEditor/Js/doctypegrideditor.controllers.js
@@ -206,8 +206,16 @@ angular.module("umbraco").controller("Our.Umbraco.DocTypeGridEditor.Dialogs.DocT
 
             function loadNode() {
                 contentResource.getScaffold(-20, $scope.model.dialogData.docTypeAlias).then(function (data) {
-                    // Remove the last tab
-                    data.tabs.pop();
+
+                    // get current umbraco version
+                    var versionArray = Umbraco.Sys.ServerVariables.application.version.split(".");
+
+                    if (parseInt(versionArray[0]) === 7 && parseInt(versionArray[1]) < 8) {
+                        // Remove the last tab, in version lower than v7.8 this is the generic properties tab
+                        data.tabs.pop();
+                    }
+
+                    
 
                     // Merge current value
                     if ($scope.model.dialogData.value) {


### PR DESCRIPTION
This PR fixes issue #88 

In v7.8 the info tab is not present in the response from  contentResource.getScaffold.

So we don't need to remove the last tab

Dave