### PR TITLE
Use label instead of alias for displaying tab text in editor dialog

### DIFF
--- a/src/Our.Umbraco.DocTypeGridEditor/Web/UI/App_Plugins/DocTypeGridEditor/Views/doctypegrideditor.dialog.html
+++ b/src/Our.Umbraco.DocTypeGridEditor/Web/UI/App_Plugins/DocTypeGridEditor/Views/doctypegrideditor.dialog.html
@@ -11,7 +11,7 @@
         <div ng-switch-when="edit">
 
             <fieldset ng-repeat="tab in model.node.tabs">
-                <legend style="font-size: 18px;">{{tab.alias}}</legend>
+                <legend style="font-size: 18px;">{{tab.label}}</legend>
 
                 <umb-property property="property"
                               ng-repeat="property in tab.properties">


### PR DESCRIPTION
When using an dictionary item for the property tabs the rendering of the tab isn't translated as shown on this screenshot:
![dtge-tab-dictionary-issue](https://user-images.githubusercontent.com/2156402/36202045-86ed0734-1182-11e8-8620-5df45eaa35ed.PNG)

In my example I have a property tab with the name "#t_Content". This should automatically be translated with the matching dictionary item ("t_Content") when shown in any editor.

With a simple fix: using the "label" instead of "alias" the matching dictionary value is shown:
![dtge-tab-dictionary-fixed](https://user-images.githubusercontent.com/2156402/36202044-86d7e34a-1182-11e8-9b47-680831806a37.PNG)
