### PR TITLE
Removed setting the `InPreviewMode` flag

### DIFF
--- a/docs/developers-guide.md
+++ b/docs/developers-guide.md
@@ -139,11 +139,11 @@ Because we treat your data as a standard `IPublishedContent` entity, that means 
 
 #### Rendering Alternative Preview Content
 
-If your front end view is rather complex, you may decide that you want to feed the back office preview an alternative, less complex view. To do this, within your Razor view/partial, check `ViewData["dtgePreview"]` is set to true to detect being in preview mode to provide an alternative view.
+If your front end view is rather complex, you may decide that you want to feed the back office preview an alternative, less complex view. To do this, within your Razor view/partial, check for a querystring parameter `dtgePreview` being set to "1" to detect being in preview mode to provide an alternative view.
 
 ```
 @inherits Umbraco.Web.Mvc.UmbracoViewPage
-@if (ViewData["dtgePreview"] == true)
+@if (Request.QueryString["dtgePreview"] == "1")
 {
 	// Render preview view
 }

--- a/docs/developers-guide.md
+++ b/docs/developers-guide.md
@@ -4,12 +4,12 @@
 
 1. [Introduction](#introduction)
 2. [Getting Set Up](#getting-set-up)
-  a. [System Requirements](#system-requirements)
+    1. [System Requirements](#system-requirements)
 3. [Configuring The Doc Type Grid Editor](#configuring-the-doc-type-grid-editor)
 4. [Hooking Up The Doc Type Grid Editor](#hooking-up-the-doc-type-grid-editor)
 5. [Rendering a Doc Type Grid Editor](#rendering-a-doc-type-grid-editor)
-  a. [Rendering Alternative Preview Content](#rendering-alternative-preview-content)
-  b. [DocTypeGridEditorSurfaceController](#doctypegrideditorsurfacecontroller)
+    1. [Rendering Alternative Preview Content](#rendering-alternative-preview-content)
+    2. [DocTypeGridEditorSurfaceController](#doctypegrideditorsurfacecontroller)
 6. [Useful Links](#useful-links)
 
 ---
@@ -139,11 +139,11 @@ Because we treat your data as a standard `IPublishedContent` entity, that means 
 
 #### Rendering Alternative Preview Content
 
-If your front end view is rather complex, you may decide that you want to feed the back office preview an alternative, less complex view. To do this, within your Razor view/partial, check `UmbracoContext.InPreviewMode` is set to true to detect being in preview mode to provide an alternative view.
+If your front end view is rather complex, you may decide that you want to feed the back office preview an alternative, less complex view. To do this, within your Razor view/partial, check `ViewData["dtgePreview"]` is set to true to detect being in preview mode to provide an alternative view.
 
 ```
 @inherits Umbraco.Web.Mvc.UmbracoViewPage
-@if (UmbracoContext.InPreviewMode)
+@if (ViewData["dtgePreview"] == true)
 {
 	// Render preview view
 }

--- a/src/Our.Umbraco.DocTypeGridEditor/Web/Controllers/DocTypeGridEditorApiController.cs
+++ b/src/Our.Umbraco.DocTypeGridEditor/Web/Controllers/DocTypeGridEditorApiController.cs
@@ -136,10 +136,6 @@ namespace Our.Umbraco.DocTypeGridEditor.Web.Controllers
                 System.Threading.Thread.CurrentThread.CurrentUICulture = culture;
             }
 
-            // Set DTGE's preview to be in "preview mode", (storing the original value in a temp variable for resetting it later).
-            var inPreviewMode = UmbracoContext.InPreviewMode;
-            UmbracoContext.InPreviewMode = true;
-
             // Get content node object
             var content = DocTypeGridEditorHelper.ConvertValueToContent(data.Id, data.ContentTypeAlias, data.Value);
 
@@ -156,9 +152,6 @@ namespace Our.Umbraco.DocTypeGridEditor.Web.Controllers
             // Render view
             var partialName = "~/App_Plugins/DocTypeGridEditor/Render/DocTypeGridEditorPreviewer.cshtml";
             var markup = Helpers.ViewHelper.RenderPartial(partialName, model, UmbracoContext.HttpContext);
-
-            // Restore the "preview mode" to its original value
-            UmbracoContext.InPreviewMode = inPreviewMode;
 
             // Return response
             var response = new HttpResponseMessage

--- a/src/Our.Umbraco.DocTypeGridEditor/Web/Controllers/DocTypeGridEditorSurfaceController.cs
+++ b/src/Our.Umbraco.DocTypeGridEditor/Web/Controllers/DocTypeGridEditorSurfaceController.cs
@@ -50,8 +50,6 @@ namespace Our.Umbraco.DocTypeGridEditor.Web.Controllers
 
         protected override PartialViewResult PartialView(string viewName, object model)
         {
-            ViewData.Add("dtgePreview", IsPreview);
-
             if (IsPreview && string.IsNullOrWhiteSpace(PreviewViewPath) == false)
             {
                 var previewViewPath = GetFullViewPath(viewName, PreviewViewPath);

--- a/src/Our.Umbraco.DocTypeGridEditor/Web/Controllers/DocTypeGridEditorSurfaceController.cs
+++ b/src/Our.Umbraco.DocTypeGridEditor/Web/Controllers/DocTypeGridEditorSurfaceController.cs
@@ -1,4 +1,5 @@
-﻿using System.Web.Mvc;
+﻿using System;
+using System.Web.Mvc;
 using Our.Umbraco.DocTypeGridEditor.Web.Helpers;
 using Umbraco.Core;
 using Umbraco.Core.Models;
@@ -29,7 +30,7 @@ namespace Our.Umbraco.DocTypeGridEditor.Web.Controllers
 
         public bool IsPreview
         {
-            get { return UmbracoContext.InPreviewMode; }
+            get { return ControllerContext.RouteData.Values.TryGetValue("dtgePreview", out object value) && Convert.ToBoolean(value); }
         }
 
         protected PartialViewResult CurrentPartialView(object model = null)
@@ -49,6 +50,8 @@ namespace Our.Umbraco.DocTypeGridEditor.Web.Controllers
 
         protected override PartialViewResult PartialView(string viewName, object model)
         {
+            ViewData.Add("dtgePreview", IsPreview);
+
             if (IsPreview && string.IsNullOrWhiteSpace(PreviewViewPath) == false)
             {
                 var previewViewPath = GetFullViewPath(viewName, PreviewViewPath);

--- a/src/Our.Umbraco.DocTypeGridEditor/Web/Extensions/HtmlHelperExtensions.cs
+++ b/src/Our.Umbraco.DocTypeGridEditor/Web/Extensions/HtmlHelperExtensions.cs
@@ -1,7 +1,6 @@
 ﻿using System.Web;
 using System.Web.Mvc;
 using System.Web.Mvc.Html;
-using Our.Umbraco.DocTypeGridEditor.Extensions;
 using Our.Umbraco.DocTypeGridEditor.Web.Helpers;
 using Our.Umbraco.DocTypeGridEditor.Web.Mvc;
 using Umbraco.Core;
@@ -51,8 +50,6 @@ namespace Our.Umbraco.DocTypeGridEditor.Web.Extensions
                 dtgePreview = isPreview
             };
 
-            var viewData = new ViewDataDictionary() { { "dtgePreview", isPreview } };
-
             // Try looking for surface controller with action named after the editor alias
             if (string.IsNullOrWhiteSpace(editorAlias) == false && SurfaceControllerHelper.SurfaceControllerExists(controllerName, editorAlias, true))
             {
@@ -93,19 +90,19 @@ namespace Our.Umbraco.DocTypeGridEditor.Web.Extensions
                 var fullPreviewViewPath = $"{previewViewPath}{editorAlias}.cshtml";
                 if (ViewHelper.ViewExists(helper.ViewContext, fullPreviewViewPath, true))
                 {
-                    return helper.Partial(fullPreviewViewPath, content, viewData);
+                    return helper.Partial(fullPreviewViewPath, content);
                 }
 
                 fullPreviewViewPath = $"{previewViewPath}{content.DocumentTypeAlias}.cshtml";
                 if (ViewHelper.ViewExists(helper.ViewContext, fullPreviewViewPath, true))
                 {
-                    return helper.Partial(fullPreviewViewPath, content, viewData);
+                    return helper.Partial(fullPreviewViewPath, content);
                 }
 
                 fullPreviewViewPath = $"{previewViewPath}Default.cshtml";
                 if (ViewHelper.ViewExists(helper.ViewContext, fullPreviewViewPath, true))
                 {
-                    return helper.Partial(fullPreviewViewPath, content, viewData);
+                    return helper.Partial(fullPreviewViewPath, content);
                 }
             }
 
@@ -115,29 +112,29 @@ namespace Our.Umbraco.DocTypeGridEditor.Web.Extensions
                 var fullViewPath = $"{viewPath}{editorAlias}.cshtml";
                 if (ViewHelper.ViewExists(helper.ViewContext, fullViewPath, true))
                 {
-                    return helper.Partial(fullViewPath, content, viewData);
+                    return helper.Partial(fullViewPath, content);
                 }
 
                 fullViewPath = $"{viewPath}{content.DocumentTypeAlias}.cshtml";
                 if (ViewHelper.ViewExists(helper.ViewContext, fullViewPath, true))
                 {
-                    return helper.Partial(fullViewPath, content, viewData);
+                    return helper.Partial(fullViewPath, content);
                 }
 
                 fullViewPath = $"{viewPath}Default.cshtml";
                 if (ViewHelper.ViewExists(helper.ViewContext, fullViewPath, true))
                 {
-                    return helper.Partial(fullViewPath, content, viewData);
+                    return helper.Partial(fullViewPath, content);
                 }
             }
 
             // Resort to standard partial views
             if (ViewHelper.ViewExists(helper.ViewContext, editorAlias, true))
             {
-                return helper.Partial(editorAlias, content, viewData);
+                return helper.Partial(editorAlias, content);
             }
 
-            return helper.Partial(content.DocumentTypeAlias, content, viewData);
+            return helper.Partial(content.DocumentTypeAlias, content);
         }
     }
 }

--- a/src/Our.Umbraco.DocTypeGridEditor/Web/Extensions/HtmlHelperExtensions.cs
+++ b/src/Our.Umbraco.DocTypeGridEditor/Web/Extensions/HtmlHelperExtensions.cs
@@ -1,6 +1,7 @@
 ﻿using System.Web;
 using System.Web.Mvc;
 using System.Web.Mvc.Html;
+using Our.Umbraco.DocTypeGridEditor.Extensions;
 using Our.Umbraco.DocTypeGridEditor.Web.Helpers;
 using Our.Umbraco.DocTypeGridEditor.Web.Mvc;
 using Umbraco.Core;
@@ -46,8 +47,11 @@ namespace Our.Umbraco.DocTypeGridEditor.Web.Extensions
             {
                 dtgeModel = content,
                 dtgeViewPath = viewPath,
-                dtgePreviewViewPath = previewViewPath
+                dtgePreviewViewPath = previewViewPath,
+                dtgePreview = isPreview
             };
+
+            var viewData = new ViewDataDictionary() { { "dtgePreview", isPreview } };
 
             // Try looking for surface controller with action named after the editor alias
             if (string.IsNullOrWhiteSpace(editorAlias) == false && SurfaceControllerHelper.SurfaceControllerExists(controllerName, editorAlias, true))
@@ -89,19 +93,19 @@ namespace Our.Umbraco.DocTypeGridEditor.Web.Extensions
                 var fullPreviewViewPath = $"{previewViewPath}{editorAlias}.cshtml";
                 if (ViewHelper.ViewExists(helper.ViewContext, fullPreviewViewPath, true))
                 {
-                    return helper.Partial(fullPreviewViewPath, content);
+                    return helper.Partial(fullPreviewViewPath, content, viewData);
                 }
 
                 fullPreviewViewPath = $"{previewViewPath}{content.DocumentTypeAlias}.cshtml";
                 if (ViewHelper.ViewExists(helper.ViewContext, fullPreviewViewPath, true))
                 {
-                    return helper.Partial(fullPreviewViewPath, content);
+                    return helper.Partial(fullPreviewViewPath, content, viewData);
                 }
 
                 fullPreviewViewPath = $"{previewViewPath}Default.cshtml";
                 if (ViewHelper.ViewExists(helper.ViewContext, fullPreviewViewPath, true))
                 {
-                    return helper.Partial(fullPreviewViewPath, content);
+                    return helper.Partial(fullPreviewViewPath, content, viewData);
                 }
             }
 
@@ -111,29 +115,29 @@ namespace Our.Umbraco.DocTypeGridEditor.Web.Extensions
                 var fullViewPath = $"{viewPath}{editorAlias}.cshtml";
                 if (ViewHelper.ViewExists(helper.ViewContext, fullViewPath, true))
                 {
-                    return helper.Partial(fullViewPath, content);
+                    return helper.Partial(fullViewPath, content, viewData);
                 }
 
                 fullViewPath = $"{viewPath}{content.DocumentTypeAlias}.cshtml";
                 if (ViewHelper.ViewExists(helper.ViewContext, fullViewPath, true))
                 {
-                    return helper.Partial(fullViewPath, content);
+                    return helper.Partial(fullViewPath, content, viewData);
                 }
 
                 fullViewPath = $"{viewPath}Default.cshtml";
                 if (ViewHelper.ViewExists(helper.ViewContext, fullViewPath, true))
                 {
-                    return helper.Partial(fullViewPath, content);
+                    return helper.Partial(fullViewPath, content, viewData);
                 }
             }
 
             // Resort to standard partial views
             if (ViewHelper.ViewExists(helper.ViewContext, editorAlias, true))
             {
-                return helper.Partial(editorAlias, content);
+                return helper.Partial(editorAlias, content, viewData);
             }
 
-            return helper.Partial(content.DocumentTypeAlias, content);
+            return helper.Partial(content.DocumentTypeAlias, content, viewData);
         }
     }
 }

--- a/src/Our.Umbraco.DocTypeGridEditor/Web/UI/App_Plugins/DocTypeGridEditor/Js/doctypegrideditor.resources.js
+++ b/src/Our.Umbraco.DocTypeGridEditor/Web/UI/App_Plugins/DocTypeGridEditor/Js/doctypegrideditor.resources.js
@@ -35,7 +35,7 @@
                 );
             },
             getEditorMarkupForDocTypePartial: function (pageId, id, editorAlias, contentTypeAlias, value, viewPath, previewViewPath, published) {
-                var url = umbRequestHelper.convertVirtualToAbsolutePath("~/umbraco/backoffice/DocTypeGridEditorApi/DocTypeGridEditorApi/GetPreviewMarkup?pageId=" + pageId);
+                var url = umbRequestHelper.convertVirtualToAbsolutePath("~/umbraco/backoffice/DocTypeGridEditorApi/DocTypeGridEditorApi/GetPreviewMarkup?dtgePreview=1&pageId=" + pageId);
                 return $http({
                     method: 'POST',
                     url: url,


### PR DESCRIPTION
The change we introduced from #117 to trick Umbraco in thinking that it
was in full preview mode has had some bad side-effects, see issues #123,
#124 and #125 for further details.

This change removes us manually setting the `InPreviewMode` property,
and brings back the querystring param "`dtgePreview`", so a
developer can detect whether its rendering in DTGE's preview mode or
not.

I'm unsure how this change will impact #117, there is an extra level of
complexity when attempting cross-package-compatibility, (in this case
Vorto).